### PR TITLE
Fix counting of released RCs

### DIFF
--- a/src/commands/l-x.ts
+++ b/src/commands/l-x.ts
@@ -41,7 +41,9 @@ Fetching L-4 versions woocommerce!
   public static enableJsonFlag = true
 
   static flags = {
-    includeRC: Flags.boolean({char: 'r', aliases: ['rc'], description: 'Whether to include Release Candidates in the fetched versions. (WordPress is Not compatible with this)'}),
+    includeRC: Flags.boolean({char: 'r', aliases: ['rc'], description: `Whether to include Release Candidates in the fetched versions. (WordPress is NOT compatible with this).
+    By default, it returns the RCs only if UNRELEASED versions. To get all RCs for released versions, add \`--includePatches\` flag.
+    Please note that the behavior of this flag may change in the future.`}),
     includePatches: Flags.boolean({char: 'p', aliases: ['patches'], description: 'Whether to include Patches in the fetched versions. (WordPress is NOT compatible with this)'}),
   }
 
@@ -90,7 +92,7 @@ Fetching L-4 versions woocommerce!
 
         for (const version of versions) {
           const releasesAdded = output.filter(
-            release => !isRC(release),
+            release => (includeRC || !isRC(release)),
           )
 
           if (releasesAdded.length === numberOfReleases) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- Fix counting of released RCs 
- Add more elaborate description to `--includeRC`.

Related:
 - https://github.com/woocommerce/grow/issues/65
 - https://github.com/woocommerce/grow/pull/66


### Screenshots:

![image](https://github.com/woocommerce/dewped/assets/17435/ede4bac8-b02e-4963-b6ad-6800da0a58e7)

![image](https://github.com/woocommerce/dewped/assets/17435/f792b18a-a65e-47d3-ab2a-39a8cc561e5e)




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

0. checkout and `npm run build`
1. use `l-x` command with `--includeRC --includePatches`, with an offset big enough, to get some RCs. Like
   ```
   dewped latest-versions woocommerce 5 -p -r
   ```

3. Check that the number of results is equal  to offset+1


### Additional details:
