### PR TITLE
Make WP version optional

### DIFF
--- a/test/commands/platform-dependency-version.test.ts
+++ b/test/commands/platform-dependency-version.test.ts
@@ -103,11 +103,10 @@ describe('platform-dependency-version', () => {
         // Header contains the WC version.
         expect(ctx.stdout).to.have.string('WooCommerce 7.0.1')
 
-        // Should not include WP versions
+        // Should not include versions for WP and non-matching packages.
         expect(ctx.stdout).to.match(/@wordpress\/data\s*$/ms)
         expect(ctx.stdout).to.match(/react\s*$/ms)
-        // Prints packages with their versions.
-        expect(ctx.stdout).to.match(/foo\s*$/ms) // No version for unmatched package
+        expect(ctx.stdout).to.match(/foo\s*$/ms)
         // Prints WC versions
         expect(ctx.stdout).to.match(/@woocommerce\/components\s*10\.3\.0/)
         expect(ctx.stdout).to.match(/@woocommerce\/settings\s*unknown/) // Not found WC package.

--- a/test/commands/platform-dependency-version.test.ts
+++ b/test/commands/platform-dependency-version.test.ts
@@ -95,12 +95,30 @@ describe('platform-dependency-version', () => {
 
   // Test WC versions
   describe('with `--wcVersion` param', () => {
-    describe('checks dependencies versions for a given WP & WC versions', () => {
+    describe('checks dependencies versions for a given WC version', () => {
+      test
+      .stdout()
+      .command(['platform-dependency-version', '--wcVersion=7.0.1', '--dependenciesJSON=test/mocks/.externalized.json'])
+      .it('renders it in a table', ctx => {
+        // Header contains the WC version.
+        expect(ctx.stdout).to.have.string('WooCommerce 7.0.1')
+
+        // Should not include WP versions
+        expect(ctx.stdout).to.match(/@wordpress\/data\s*$/ms)
+        expect(ctx.stdout).to.match(/react\s*$/ms)
+        // Prints packages with their versions.
+        expect(ctx.stdout).to.match(/foo\s*$/ms) // No version for unmatched package
+        // Prints WC versions
+        expect(ctx.stdout).to.match(/@woocommerce\/components\s*10\.3\.0/)
+        expect(ctx.stdout).to.match(/@woocommerce\/settings\s*unknown/) // Not found WC package.
+      })
+    })
+    describe('& `--wpVersion` checks dependencies versions for a given WP & WC versions', () => {
       test
       .stdout()
       .command(['platform-dependency-version', '--wpVersion=6.0.3', '--wcVersion=7.0.1', '--dependenciesJSON=test/mocks/.externalized.json'])
       .it('renders it in a table', ctx => {
-      // Header contains the WC version.
+        // Header contains the WC version.
         expect(ctx.stdout).to.have.string('WooCommerce 7.0.1')
 
         // Prints packages with their versions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Make the `platform-dependency-version` command work without providing WP version.
As it still may be useful to show WC versions or local versions.


### Screenshots:
![image](https://github.com/woocommerce/dewped/assets/17435/ebb97c91-a156-4959-b27b-294d7df32d8b)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch and build
2. Install the local `dewped` if you want to use it in an actual repo
3. `dewped pdep --wcVersion=6.9.4 @woocommerce/components @wordpress/components`
3. `dewped pdep @woocommerce/components @wordpress/components`


